### PR TITLE
Updated version check for pressure measurement due to #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ As you now can trigger also the pressure measurement, you also get the following
  - **lpm_leakage** to show if a leakage was detected (not sure if this one is true also means you'll get a notification from Grohe or not)
  - **lpm_leakage_level** to give you a possible 'rating' of the urgency of the leakage
  - **lpm_pressure_drop** to give you the whole pressure drop during measurement
+ - **lpm_max_flow_rate** the maximum flow rate during pressure measurement from the measurement curve list
 
 **Hint:** At the moment I am not 100% sure about each of the above-mentioned sensors and their actual behaviour
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ When you install this, you get the following sensors for each Sense Guard:
 You will also get a valve device (so, be careful with `group.all_switches`, as that now includes your water) called
  - **valve**
 
+#### Pressure Measurement
+**Hint:** This is only enabled for Grohe Sense Guard with Software Version 3.6 or newer
+
 You will also get a button entity for triggering the pressure measurement
  - **pressure_measurement**
 

--- a/custom_components/grohe_sense/button.py
+++ b/custom_components/grohe_sense/button.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = []
 
     for device in filter(lambda d: d.type == GroheTypes.GROHE_SENSE_GUARD, devices):
-        entities.append(
-            GroheSenseGuardButton(DOMAIN, ondus_api, device))
+        if device.stripped_sw_version >= (3, 6):
+            entities.append(GroheSenseGuardButton(DOMAIN, ondus_api, device))
     if entities:
         async_add_entities(entities)

--- a/custom_components/grohe_sense/dto/grohe_coordinator_dtos.py
+++ b/custom_components/grohe_sense/dto/grohe_coordinator_dtos.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass, field
-from email.policy import default
 from typing import Optional
 
-from dataclasses_json import dataclass_json, Undefined, config
+from dataclasses_json import dataclass_json, config
 
-from custom_components.grohe_sense.enum.ondus_types import PressureMeasurementState
+
 
 
 @dataclass_json
@@ -19,6 +18,7 @@ class LastPressureMeasurement:
     leakage_level: Optional[int] = field(metadata=config(field_name='level'),default=None)
     duration: Optional[int] = field(metadata=config(field_name='total_duration'),default=None)
     pressure_drop: Optional[float] = field(metadata=config(field_name='drop_of_pressure'),default=None)
+    max_flow_rate: Optional[float] = None
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/custom_components/grohe_sense/dto/grohe_device.py
+++ b/custom_components/grohe_sense/dto/grohe_device.py
@@ -31,6 +31,10 @@ class GroheDevice:
         return self.appliance.version
 
     @property
+    def stripped_sw_version(self) -> tuple[int, ...]:
+        return tuple(map(int, self.appliance.version.split('.')[:2]))
+
+    @property
     def name(self) -> str:
         return self.appliance.name
 

--- a/custom_components/grohe_sense/entities/configuration/grohe_entity_configuration.py
+++ b/custom_components/grohe_sense/entities/configuration/grohe_entity_configuration.py
@@ -22,6 +22,7 @@ class SensorTypes(Enum):
     LPM_LEAKAGE_LEVEL = 'lpm_leakage_level'
     LPM_PRESSURE_DROP = 'lpm_pressure_drop'
     LPM_DURATION = 'lpm_duration'
+    LPM_MAX_FLOW_RATE = 'lpm_max_flow_rate'
     LPM_ESTIMATED_STOP_TIME = 'lpm_estimated_stop_time'
     # Sensors for Grohe BLUE
     CLEANING_COUNT = 'cleaning_count'
@@ -72,6 +73,7 @@ GROHE_ENTITY_CONFIG: Dict[GroheTypes, List[SensorTypes]] = {
                                    SensorTypes.LPM_LEAKAGE_LEVEL,
                                    SensorTypes.LPM_PRESSURE_DROP,
                                    SensorTypes.LPM_DURATION,
+                                   SensorTypes.LPM_MAX_FLOW_RATE,
                                    ],
     GroheTypes.GROHE_BLUE_PROFESSIONAL: [SensorTypes.NOTIFICATION,
                                          SensorTypes.CLEANING_COUNT,
@@ -136,6 +138,9 @@ SENSOR_CONFIGURATION: Dict[SensorTypes, Sensor] = {
     SensorTypes.LPM_LEAKAGE_LEVEL: Sensor(None, None, lambda x: x),
     SensorTypes.LPM_PRESSURE_DROP: Sensor(SensorDeviceClass.PRESSURE, UnitOfPressure.BAR, lambda x: x),
     SensorTypes.LPM_DURATION: Sensor(SensorDeviceClass.DURATION, UnitOfTime.SECONDS, lambda x: x),
+    SensorTypes.LPM_MAX_FLOW_RATE: Sensor(SensorDeviceClass.VOLUME_FLOW_RATE,
+                                          UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+                                          lambda x: x * 3.6),
     # From here Blue Sensors are configured
     SensorTypes.CLEANING_COUNT: Sensor(None, None, lambda x: x),
     SensorTypes.DATE_OF_CLEANING: Sensor(SensorDeviceClass.TIMESTAMP, None, lambda x: x),

--- a/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
+++ b/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
@@ -84,6 +84,11 @@ class GroheSenseUpdateCoordinator(DataUpdateCoordinator):
         measurement: LastPressureMeasurement | None = None
         if appliance_details and appliance_details.last_pressure_measurement is not None:
             measurement = LastPressureMeasurement.from_dict(appliance_details.last_pressure_measurement.to_dict())
+            if appliance_details.last_pressure_measurement.pressure_curve is not None:
+                curve = appliance_details.last_pressure_measurement.pressure_curve
+                flow_rates = [flow.fr for flow in curve]
+                flow_rates.sort(reverse=True)
+                measurement.max_flow_rate = flow_rates[0] if len(flow_rates) > 0 else None
 
         return measurement
 

--- a/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
+++ b/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
@@ -84,12 +84,16 @@ class GroheSenseUpdateCoordinator(DataUpdateCoordinator):
         measurement: LastPressureMeasurement | None = None
         if appliance_details and appliance_details.last_pressure_measurement is not None:
             measurement = LastPressureMeasurement.from_dict(appliance_details.last_pressure_measurement.to_dict())
+            _LOGGER.debug(f'PRESSURE MEASUREMENT -> Received the following pressure measurement for '
+                          f'appliance {self._device.appliance_id}: {measurement}')
             if appliance_details.last_pressure_measurement.pressure_curve is not None:
                 curve = appliance_details.last_pressure_measurement.pressure_curve
                 flow_rates = [flow.fr for flow in curve]
                 flow_rates.sort(reverse=True)
                 measurement.max_flow_rate = flow_rates[0] if len(flow_rates) > 0 else None
-
+        elif appliance_details is not None:
+            _LOGGER.debug(f'PRESSURE MEASUREMENT -> Did a pressure measurement for appliance'
+                          f' {self._device.appliance_id} but only received the following data: {appliance_details}')
         return measurement
 
 
@@ -126,7 +130,9 @@ class GroheSenseUpdateCoordinator(DataUpdateCoordinator):
             data.withdrawal = await self._get_withdrawal()
             data.measurement = await self._get_actual_measurement()
             data.notification = await self._get_notification()
-            data.last_pressure_measurement = await self._get_last_pressure_measurement()
+
+            if self._device.type == GroheTypes.GROHE_SENSE_GUARD:
+                data.last_pressure_measurement = await self._get_last_pressure_measurement()
 
             self._last_update = datetime.now().astimezone().replace(tzinfo=self._timezone)
             return data

--- a/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
+++ b/custom_components/grohe_sense/entities/grohe_sense_update_coordinator.py
@@ -78,6 +78,8 @@ class GroheSenseUpdateCoordinator(DataUpdateCoordinator):
         return measurement_data
 
     async def _get_last_pressure_measurement(self) -> LastPressureMeasurement | None:
+        _LOGGER.debug(f'Get last pressure measurement for appliance {self._device.appliance_id}')
+
         appliance_details = await self._api.get_appliance_details(self._device.location_id, self._device.room_id,
                                                                   self._device.appliance_id)
 
@@ -125,7 +127,7 @@ class GroheSenseUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> CoordinatorDto:
         try:
-
+            _LOGGER.debug(f'Updating {self._device.type} (appliance = {self._device.appliance_id}) data')
             data = CoordinatorDto()
             data.withdrawal = await self._get_withdrawal()
             data.measurement = await self._get_actual_measurement()

--- a/custom_components/grohe_sense/enum/ondus_types.py
+++ b/custom_components/grohe_sense/enum/ondus_types.py
@@ -25,3 +25,4 @@ class PressureMeasurementState(Enum):
     SUCCESS = 'SUCCESS'
     START = 'START'
     START_FAILED = 'START_FAILED'
+    STOP = 'STOP'

--- a/custom_components/grohe_sense/enum/ondus_types.py
+++ b/custom_components/grohe_sense/enum/ondus_types.py
@@ -24,3 +24,4 @@ class OndusCommands(Enum):
 class PressureMeasurementState(Enum):
     SUCCESS = 'SUCCESS'
     START = 'START'
+    START_FAILED = 'START_FAILED'

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -9,5 +9,5 @@
 	"requirements": [
 		"dataclasses-json==0.6.7"
 	],
-	"version": "v0.9.11"
+	"version": "v0.9.12"
 }

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -9,5 +9,5 @@
 	"requirements": [
 		"dataclasses-json==0.6.7"
 	],
-	"version": "v0.9.10"
+	"version": "v0.9.11"
 }

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -9,5 +9,5 @@
 	"requirements": [
 		"dataclasses-json==0.6.7"
 	],
-	"version": "v0.9.8"
+	"version": "v0.9.9"
 }

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -9,5 +9,5 @@
 	"requirements": [
 		"dataclasses-json==0.6.7"
 	],
-	"version": "v0.9.9"
+	"version": "v0.9.10"
 }

--- a/custom_components/grohe_sense/sensor.py
+++ b/custom_components/grohe_sense/sensor.py
@@ -44,7 +44,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                                  SensorTypes.LPM_ESTIMATED_STOP_TIME, SensorTypes.LPM_START_TIME,
                                  SensorTypes.LPM_PRESSURE_DROP, SensorTypes.LPM_LEAKAGE, SensorTypes.LPM_STATUS,
                                  SensorTypes.LPM_MAX_FLOW_RATE]:
-                    entities.append(GroheSenseGuardLastPressureEntity(DOMAIN, coordinator, device, sensors))
+                    if device.stripped_sw_version >= (3, 6):
+                        entities.append(GroheSenseGuardLastPressureEntity(DOMAIN, coordinator, device, sensors))
                 else:
                     entities.append(GroheSensorEntity(DOMAIN, coordinator, device, sensors))
         else:

--- a/custom_components/grohe_sense/sensor.py
+++ b/custom_components/grohe_sense/sensor.py
@@ -42,7 +42,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     entities.append(GroheSenseNotificationEntity(DOMAIN, coordinator, device, sensors))
                 elif sensors in [SensorTypes.LPM_DURATION, SensorTypes.LPM_LEAKAGE_LEVEL,
                                  SensorTypes.LPM_ESTIMATED_STOP_TIME, SensorTypes.LPM_START_TIME,
-                                 SensorTypes.LPM_PRESSURE_DROP, SensorTypes.LPM_LEAKAGE, SensorTypes.LPM_STATUS]:
+                                 SensorTypes.LPM_PRESSURE_DROP, SensorTypes.LPM_LEAKAGE, SensorTypes.LPM_STATUS,
+                                 SensorTypes.LPM_MAX_FLOW_RATE]:
                     entities.append(GroheSenseGuardLastPressureEntity(DOMAIN, coordinator, device, sensors))
                 else:
                     entities.append(GroheSensorEntity(DOMAIN, coordinator, device, sensors))


### PR DESCRIPTION
#24. Due to an issue with the pressure measurement not being available in (at least versions smaller than 3.6) I have disabled these sensors for those devices. If there is more known towards that, it will maybe will be enabled for older software versions as well)
