### PR TITLE
Move dev to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The following Actions are available:
  - Grohe Sense: Get Profile notifications
  - Grohe Sense: Get Appliance command
  - Grohe Sense: Set Appliance command
+ - Grohe Sense: Tap Water
 
 ## Installation
 

--- a/custom_components/grohe_sense/__init__.py
+++ b/custom_components/grohe_sense/__init__.py
@@ -304,7 +304,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_register(
         DOMAIN,
         'tap_water',
-        handle_tap_water(),
+        handle_tap_water,
         schema=voluptuous.Schema({
             voluptuous.Required('device_name'): str,
             voluptuous.Required('water_type'): str,

--- a/custom_components/grohe_sense/dto/grohe_device.py
+++ b/custom_components/grohe_sense/dto/grohe_device.py
@@ -24,6 +24,10 @@ class GroheDevice:
         return self._room_id
 
     @property
+    def room_name(self) -> str:
+        return self._room_name
+
+    @property
     def appliance_id(self) -> str:
         return self.appliance.id
 

--- a/custom_components/grohe_sense/dto/grohe_device.py
+++ b/custom_components/grohe_sense/dto/grohe_device.py
@@ -9,9 +9,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class GroheDevice:
-    def __init__(self, location_id: int, room_id: int, appliance: Appliance):
+    def __init__(self, location_id: int, room_id: int, room_name: str, appliance: Appliance):
         self._location_id = location_id
         self._room_id = room_id
+        self._room_name = room_name
         self.appliance = appliance
 
     @property
@@ -86,7 +87,7 @@ class GroheDevice:
                     )
 
                     try:
-                        device: GroheDevice = GroheDevice(location.id, room.id, appliance)
+                        device: GroheDevice = GroheDevice(location.id, room.id, room.name, appliance)
                         if not device.is_valid_device_type():
                             app_details = await ondus_api.get_appliance_details_raw(
                                 location.id, room.id, appliance.id)

--- a/custom_components/grohe_sense/entities/entity/sensor.py
+++ b/custom_components/grohe_sense/entities/entity/sensor.py
@@ -30,6 +30,7 @@ class Sensor(CoordinatorEntity, SensorEntity):
 
         # Needed for Sensor Entity
         self._attr_name = f'{self._device.name} {self._sensor.name}'
+        self._attr_has_entity_name = True
 
         self._attr_entity_registry_enabled_default = self._sensor.enabled
 

--- a/custom_components/grohe_sense/entities/entity/sensor.py
+++ b/custom_components/grohe_sense/entities/entity/sensor.py
@@ -51,7 +51,8 @@ class Sensor(CoordinatorEntity, SensorEntity):
                           name=self._device.name,
                           manufacturer='Grohe',
                           model=self._device.device_name,
-                          sw_version=self._device.sw_version)
+                          sw_version=self._device.sw_version,
+                          suggested_area=self._device.room_name)
 
     @property
     def unique_id(self):

--- a/custom_components/grohe_sense/entities/entity/todo.py
+++ b/custom_components/grohe_sense/entities/entity/todo.py
@@ -39,7 +39,8 @@ class Todo(CoordinatorEntity, TodoListEntity):
                           name=self._device.name,
                           manufacturer='Grohe',
                           model=self._device.device_name,
-                          sw_version=self._device.sw_version)
+                          sw_version=self._device.sw_version,
+                          suggested_area=self._device.room_name)
 
     @property
     def unique_id(self):

--- a/custom_components/grohe_sense/entities/entity/todo.py
+++ b/custom_components/grohe_sense/entities/entity/todo.py
@@ -30,6 +30,7 @@ class Todo(CoordinatorEntity, TodoListEntity):
 
         # Needed for TodoEntity
         self._attr_name = f'{self._device.name} {self._todo.name}'
+        self._attr_has_entity_name = True
         self._attr_todo_items = []
         self._attr_supported_features = TodoListEntityFeature.UPDATE_TODO_ITEM | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
 

--- a/custom_components/grohe_sense/entities/entity/valve.py
+++ b/custom_components/grohe_sense/entities/entity/valve.py
@@ -34,6 +34,7 @@ class Valve(ValveEntity):
         self._attr_icon = 'mdi:water'
 
         self._attr_name = f'{self._device.name} {self._valve.name}'
+        self._attr_has_entity_name = True
 
         self._attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
 

--- a/custom_components/grohe_sense/entities/entity/valve.py
+++ b/custom_components/grohe_sense/entities/entity/valve.py
@@ -50,7 +50,8 @@ class Valve(ValveEntity):
                           name=self._device.name,
                           manufacturer='Grohe',
                           model=self._device.device_name,
-                          sw_version=self._device.sw_version)
+                          sw_version=self._device.sw_version,
+                          suggested_area=self._device.room_name)
 
     @property
     def reports_position(self) -> bool:

--- a/custom_components/grohe_sense/entities/entity_helper.py
+++ b/custom_components/grohe_sense/entities/entity_helper.py
@@ -43,23 +43,23 @@ class EntityHelper:
 
 
     async def add_sensor_entities(self, coordinator: CoordinatorInterface, device: GroheDevice,
-                                  notification_config: NotificationsDto, async_add_entities):
+                                  notification_config: NotificationsDto) -> List[Sensor]:
 
         config_name = self._get_config_name_by_device_type(device)
 
+        entities: List = []
         if config_name:
-            entities: List = []
             initial_value = await coordinator.get_initial_value()
             if self._config.get_device_config(config_name) is not None:
                 for sensor in self._config.get_device_config(config_name).sensors:
                     if self._is_valid_version(device, sensor):
                         _LOGGER.debug(f'Adding sensor {sensor.name} for device {device.name}')
                         entities.append(Sensor(self._domain, coordinator, device, sensor, notification_config, initial_value))
-            if entities:
-                async_add_entities(entities, update_before_add=True)
+        return entities
+
 
     async def add_todo_entities(self, coordinator: CoordinatorInterface, device: GroheDevice,
-                                notification_config: NotificationsDto, async_add_entities):
+                                notification_config: NotificationsDto) -> List[Todo]:
 
         config_name = self._get_config_name_by_device_type(device)
 
@@ -69,22 +69,22 @@ class EntityHelper:
             for todo in self._config.get_device_config(config_name).todos:
                 _LOGGER.debug(f'Adding todo {todo.name} for device {device.name}')
                 entities.append(Todo(self._domain, coordinator, device, todo, notification_config))
-        if entities:
-            async_add_entities(entities, update_before_add=True)
+
+        return entities
 
 
-    async def add_valve_entities(self, coordinator: CoordinatorInterface, device: GroheDevice, async_add_entities):
+    async def add_valve_entities(self, coordinator: CoordinatorInterface, device: GroheDevice) -> List[Valve]:
 
         config_name = self._get_config_name_by_device_type(device)
 
+        entities: List[Valve] = []
         if config_name:
-            entities: List = []
-            initial_value = await coordinator.get_initial_value()
             if (self._config.get_device_config(config_name) is not None
                     and self._config.get_device_config(config_name).valves is not None):
                 for valve in self._config.get_device_config(config_name).valves:
                     _LOGGER.debug(f'Adding valve {valve.name} for device {device.name}')
                     entities.append(Valve(self._domain, coordinator, device, valve))
-            if entities:
-                async_add_entities(entities, update_before_add=True)
+
+        return entities
+
 

--- a/custom_components/grohe_sense/enum/ondus_types.py
+++ b/custom_components/grohe_sense/enum/ondus_types.py
@@ -22,3 +22,8 @@ class PressureMeasurementState(Enum):
     START = 'START'
     START_FAILED = 'START_FAILED'
     STOP = 'STOP'
+
+class GroheTapType(Enum):
+    STILL = 1
+    MEDIUM = 2
+    CARBONATED = 3

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -1,6 +1,6 @@
 {
 	"domain": "grohe_sense",
-	"name": "Grohe Sense",
+	"name": "Grohe Sense and Blue",
 	"codeowners": ["@Flo-Schilli"],
 	"config_flow": true,
 	"documentation": "https://github.com/Flo-Schilli/homeassistant-grohe_sense",

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -11,5 +11,5 @@
 		"lxml==5.3.0",
 		"python-benedict==0.34.0"
 	],
-	"version": "v0.21.0"
+	"version": "v0.22.0"
 }

--- a/custom_components/grohe_sense/sensor.py
+++ b/custom_components/grohe_sense/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from .const import (DOMAIN)
 from .dto.config_dtos import ConfigDto, NotificationsDto
 from .dto.grohe_device import GroheDevice
+from .entities.entity.sensor import Sensor
 from .entities.entity_helper import EntityHelper
 from .entities.interface.coordinator_interface import CoordinatorInterface
 
@@ -15,13 +16,18 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     _LOGGER.debug(f'Adding sensor entities from config entry {entry}')
 
-    devices: List[GroheDevice] = hass.data[DOMAIN]['devices']
-    config: ConfigDto = hass.data[DOMAIN]['config']
-    coordinators: Dict[str, CoordinatorInterface] = hass.data[DOMAIN]['coordinator']
-    notification_config: NotificationsDto = hass.data[DOMAIN]['notifications']
+    data = hass.data[DOMAIN][entry.entry_id]
+    devices: List[GroheDevice] = data['devices']
+    config: ConfigDto = data['config']
+    coordinators: Dict[str, CoordinatorInterface] = data['coordinator']
+    notification_config: NotificationsDto = data['notifications']
     helper: EntityHelper = EntityHelper(config, DOMAIN)
 
+    entities: List[Sensor] = []
     for device in devices:
         coordinator = coordinators.get(device.appliance_id, None)
         if coordinator is not None:
-            await helper.add_sensor_entities(coordinator, device, notification_config, async_add_entities)
+            entities.extend(await helper.add_sensor_entities(coordinator, device, notification_config))
+
+    if entities:
+        async_add_entities(entities)

--- a/custom_components/grohe_sense/services.yaml
+++ b/custom_components/grohe_sense/services.yaml
@@ -111,3 +111,33 @@ get_profile_notifications:
           mode: box
           min: 1
           max: 50
+
+tap_water:
+  name: Tap water
+  description: Tap water from Grohe Blue Home/Professional
+  fields:
+    device_name:
+      name: Device name
+      description: The name of the device from which you want to tap water
+      required: true
+      selector:
+        text:
+    water_type:
+      name: Water type
+      description: You can choose between [still, medium, carbonated]
+      required: true
+      selector:
+        select:
+          options:
+            - Still
+            - Medium
+            - Carbonated
+    amount:
+      name: Water amount
+      description: The amount of water which shall be taped
+      required: true
+      selector:
+        number:
+          min: 10
+          max: 1500
+          step: 10

--- a/custom_components/grohe_sense/strings.json
+++ b/custom_components/grohe_sense/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Setup Grohe Sense",
+    "flow_title": "Setup Grohe Sense and Blue",
     "step": {
       "user": {
         "title": "Login to Grohe",

--- a/custom_components/grohe_sense/todo.py
+++ b/custom_components/grohe_sense/todo.py
@@ -7,6 +7,7 @@ from .api.ondus_api import OndusApi
 from .const import (DOMAIN)
 from .dto.config_dtos import ConfigDto, NotificationDto, NotificationsDto
 from .dto.grohe_device import GroheDevice
+from .entities.entity.todo import Todo
 from .entities.entity_helper import EntityHelper
 from .entities.interface.coordinator_interface import CoordinatorInterface
 
@@ -16,15 +17,20 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     _LOGGER.debug(f'Adding todo entities from config entry {entry}')
 
-    api: OndusApi = hass.data[DOMAIN]['session']
-    config: ConfigDto = hass.data[DOMAIN]['config']
-    devices: List[GroheDevice] = hass.data[DOMAIN]['devices']
-    coordinators: Dict[str, CoordinatorInterface] = hass.data[DOMAIN]['coordinator']
-    notification_config: NotificationsDto = hass.data[DOMAIN]['notifications']
+    data = hass.data[DOMAIN][entry.entry_id]
+    api: OndusApi = data['session']
+    devices: List[GroheDevice] = data['devices']
+    config: ConfigDto = data['config']
+    coordinators: Dict[str, CoordinatorInterface] = data['coordinator']
+    notification_config: NotificationsDto = data['notifications']
     helper: EntityHelper = EntityHelper(config, DOMAIN)
 
+    entities: List[Todo] = []
     for device in devices:
         if coordinators.get(api.get_user_claim(), None) is not None:
-            await helper.add_todo_entities(coordinators.get(api.get_user_claim(), None), device,
-                                           notification_config, async_add_entities)
+            entity = await helper.add_todo_entities(coordinators.get(api.get_user_claim(), None), device,
+                                           notification_config)
+            entities.extend(entity)
 
+    if entities:
+        async_add_entities(entities)

--- a/custom_components/grohe_sense/valve.py
+++ b/custom_components/grohe_sense/valve.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 from . import (DOMAIN)
 from .dto.config_dtos import ConfigDto
 from .dto.grohe_device import GroheDevice
+from .entities.entity.valve import Valve
 from .entities.entity_helper import EntityHelper
 from .entities.interface.coordinator_interface import CoordinatorInterface
 
@@ -16,12 +17,17 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     _LOGGER.debug(f'Adding valve entities from config entry {entry}')
 
-    devices: List[GroheDevice] = hass.data[DOMAIN]['devices']
-    config: ConfigDto = hass.data[DOMAIN]['config']
-    coordinators: Dict[str, CoordinatorInterface] = hass.data[DOMAIN]['coordinator']
+    data = hass.data[DOMAIN][entry.entry_id]
+    devices: List[GroheDevice] = data['devices']
+    config: ConfigDto = data['config']
+    coordinators: Dict[str, CoordinatorInterface] = data['coordinator']
     helper: EntityHelper = EntityHelper(config, DOMAIN)
 
+    entities: List[Valve] = []
     for device in devices:
         coordinator = coordinators.get(device.appliance_id, None)
         if coordinator is not None:
-            await helper.add_valve_entities(coordinator, device, async_add_entities)
+            entities.extend(await helper.add_valve_entities(coordinator, device))
+
+    if entities:
+        async_add_entities(entities)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Grohe Sense",
+  "name": "Grohe Sense and Blue",
   "render_readme": true,
   "country": ["DE"]
 }


### PR DESCRIPTION
Bump to new Version 0.22.0

## Added
- New Action for tapping water for Grohe Blue devices
- #50: Added room name suggestions (showing the actual room names from Grohe) to give a hint where the devices are located if they are named the same way.
Hint: This generates them automatically in the areas which - if unwanted - need to be removed there afterwards
- async_unload_entry added for being able to do a hot reload of device list

## Fixed
- async_add_entities now without update_before_add, as it then has not shown all devices in the list when updating
- aiohttp_session now with create instead of get, this fixes #53