### PR TITLE
Fixed #56

### DIFF
--- a/custom_components/grohe_sense/dto/grohe_device.py
+++ b/custom_components/grohe_sense/dto/grohe_device.py
@@ -37,7 +37,12 @@ class GroheDevice:
 
     @property
     def stripped_sw_version(self) -> tuple[int, ...]:
-        return tuple(map(int, self.appliance.version.split('.')[:2]))
+        try:
+            version = tuple(map(int, self.appliance.version.split('.')[:2]))
+        except ValueError:
+            _LOGGER.warning(f'SW-Version for {self.appliance.name} cannot be split into two numbers. Value is: "{self.appliance.version}"')
+            version = (0, 0)
+        return version
 
     @property
     def name(self) -> str:

--- a/custom_components/grohe_sense/manifest.json
+++ b/custom_components/grohe_sense/manifest.json
@@ -11,5 +11,5 @@
 		"lxml==5.3.0",
 		"python-benedict==0.34.0"
 	],
-	"version": "v0.22.1"
+	"version": "v0.22.2"
 }


### PR DESCRIPTION
## Fixed
#56 If version if Grohe Sense Guard is not numeric (e.g. empty) log a warning and proceed with version 0.0, so that no version specific entities get exposed